### PR TITLE
Allow diesel generator to startup at start

### DIFF
--- a/code/simple_model.py
+++ b/code/simple_model.py
@@ -695,15 +695,15 @@ def setUpDiesel(model, ini):
     )
 
     model.addConstr(
-        (dieselStatusVars[0, 2] == 0),
+        (dieselStatusVars[0, 3] == 0),
         "diesel generator is not in status committed at start",
     )
     model.addConstr(
-        (dieselStatusVars[0, 3] == 0), "diesel generator is not in shutdown at start"
+        (dieselStatusVars[0, 2] == 0), "diesel generator is not in shutdown at start"
     )
     model.addConstr(
-        ((dieselStatusVars[0, 1] == 1) >> (dieselGeneratorsVars[0, 0] == 0)),
-        "Also when starting in startup mode the generation has to be 0",
+        (dieselGeneratorsVars[0, 0] == 0),
+        "In any case at start the generation has to be 0",
     )
 
     model.addConstr(

--- a/code/simple_model.py
+++ b/code/simple_model.py
@@ -695,8 +695,17 @@ def setUpDiesel(model, ini):
     )
 
     model.addConstr(
-        (dieselStatusVars[0, 0] == 1), "diesel generator is not committed at start"
+        (dieselStatusVars[0, 2] == 0),
+        "diesel generator is not in status committed at start",
     )
+    model.addConstr(
+        (dieselStatusVars[0, 3] == 0), "diesel generator is not in shutdown at start"
+    )
+    model.addConstr(
+        ((dieselStatusVars[0, 1] == 1) >> (dieselGeneratorsVars[0, 0] == 0)),
+        "Also when starting in startup mode the generation has to be 0",
+    )
+
     model.addConstr(
         (dieselStatusVars[len(ini.timestamps) - 1, 0] == 1),
         "Diesel Generator status in the end of simulation",


### PR DESCRIPTION
Make a small improvement by allowing the diesel generator to start in *startup* mode.